### PR TITLE
Remove unused `test_env?` check

### DIFF
--- a/lib/idnow.rb
+++ b/lib/idnow.rb
@@ -57,11 +57,6 @@ module Idnow
     @api_key = api_key
   end
 
-  def test_env?
-    fail 'Please set env to :test or :live' if host.nil?
-    Idnow.host.include?('test')
-  end
-
   def client
     fail 'Please set your company_id' if company_id.nil?
     fail 'Please set your api_key' if api_key.nil?
@@ -70,5 +65,5 @@ module Idnow
   end
 
   module_function :host, :target_host, :company_id, :api_key, :env=,
-                  :company_id=, :api_key=, :test_env?, :client
+                  :company_id=, :api_key=, :client
 end

--- a/spec/unit/idnow_spec.rb
+++ b/spec/unit/idnow_spec.rb
@@ -78,30 +78,6 @@ RSpec.describe Idnow do
     end
   end
 
-  describe '.test_env?' do
-    subject { Idnow.test_env? }
-    context 'when no env was set' do
-      before do
-        Idnow.instance_variable_set(:@host, nil)
-      end
-      it { expect { subject }.to raise_error(RuntimeError, 'Please set env to :test or :live') }
-    end
-
-    context 'when env was set to :test' do
-      before do
-        Idnow.env = :test
-      end
-      it { is_expected.to be_truthy }
-    end
-
-    context 'when env was set to :live' do
-      before do
-        Idnow.env = :live
-      end
-      it { is_expected.to be_falsey }
-    end
-  end
-
   describe '.client' do
     subject { Idnow.client }
 


### PR DESCRIPTION
Removed as never used. This should sit on client anyway, if needed. It can lead to problems with multiple clients in parallel.
