### PR TITLE
Add dockerized build/test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git*
+log/*
+tmp/*
+README.md
+.env
+id_rsa
+id_rsa.pub
+.bundle
+vendor/bundle
+Gemfile.lock

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,12 @@
-test:
-	bundle exec rspec
+DOCKER_TAG=solarisbank/idnow-client-test
+
+rspec:
+	docker run -t $(DOCKER_TAG) rspec
+
+rubocop:
+	docker run -t $(DOCKER_TAG) rubocop
+
+test: rubocop rspec
+
+build:
+	docker build -t $(DOCKER_TAG) -f ci/Dockerfile .

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.2.3
+
+RUN mkdir /gem \
+    && mkdir /var/bundle
+
+COPY Gemfile /gem/
+COPY idnow-client.gemspec /gem/
+WORKDIR /gem
+
+RUN bundle install --path /var/bundle
+ADD . /gem
+
+ENTRYPOINT ["bundle", "exec"]


### PR DESCRIPTION
see https://trello.com/c/N8JB08Kz/63-migrate-from-external-circleci-to-internal-gocd

We're moving to dockerized testing for easy dependency management. The resulting image won't be pushed – it is merely built for testing.

GoCD location for this project is: https://gocd.solarisbank.de/go/tab/pipeline/history/idnow-client

Please note that this first PR check on GoCD will be broken, as it needs a successful check against master first.