### PR TITLE
Shorten mobile number to pass E.164 validation

### DIFF
--- a/spec/support/factories/identification.rb
+++ b/spec/support/factories/identification.rb
@@ -65,7 +65,7 @@ FactoryGirl.define do
             "custom5": null
           },
           "contactdata": {
-            "mobilephone": "+4915193875727462264",
+            "mobilephone": "+4915193875727",
             "email": "petra.meier@example.com"
           },
           "userdata": {

--- a/spec/unit/models/contact_data_spec.rb
+++ b/spec/unit/models/contact_data_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Idnow::ContactData do
 
   describe '#mobilephone' do
     subject { contact_data.mobilephone }
-    it { is_expected.to eq '+4915193875727462264' }
+    it { is_expected.to eq '+4915193875727' }
   end
 end


### PR DESCRIPTION
We will have to introduce a validation on mobile number in core-banking. The fake number used by the idnow-client until now is not valid and had to be shortened.