### PR TITLE
support preferredLang attribute

### DIFF
--- a/lib/idnow/models/identification_data.rb
+++ b/lib/idnow/models/identification_data.rb
@@ -10,7 +10,8 @@ module Idnow
 
     attr_accessor :birthplace, :birthname, :city, :country, :custom1,
                   :custom2, :custom3, :custom4, :custom5, :trackingid, :email, :firstname, :gender,
-                  :lastname, :mobilephone, :nationality, :street, :streetnumber, :title, :zipcode
+                  :lastname, :mobilephone, :nationality, :street, :streetnumber, :title, :zipcode,
+                  :preferredLang
 
     def initialize(params = {})
       params.keys.each do |key|


### PR DESCRIPTION
As per recent IDNow documentation, it's possible to pass a `preferredLang` attribute, which would in turn be a deciding factor in in which language the contents are being shown to the user.