### PR TITLE
Allow to configure custom endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The Idnow client takes three settings:
 
 *  **company_id**
 *  **api_key**
+*  **custom_environments** (optional)
 
 You have the option of using a global singleton client:
 
@@ -38,6 +39,18 @@ You have the option of using a global singleton client:
 Idnow.env = :test
 Idnow.company_id = "mycompany"
 Idnow.api_key = "1234api_key"
+
+# optional
+Idnow.custom_environments = {
+  test: {
+    host:        'https://gateway.test.idnow.example.com',
+    target_host: 'https://go.test.idnow.example.com'
+  },
+  live: {
+    host:        'https://gateway.idnow.example.com',
+    target_host: 'https://go.idnow.example.com'
+  }
+}
 ```
 
 Or many clients can be initialized with:

--- a/lib/idnow.rb
+++ b/lib/idnow.rb
@@ -61,9 +61,18 @@ module Idnow
     @api_key = api_key
   end
 
+  def custom_environments=(custom_environments)
+    @client = nil
+    @custom_environments = custom_environments
+  end
+
+  def endpoint(env, host)
+    (@custom_environments || {}).dig(env, host) || Idnow::ENVIRONMENTS[env][host]
+  end
+
   def client
     @client ||= Idnow::Client.new(env: @env, company_id: @company_id, api_key: @api_key)
   end
 
-  module_function :env=, :company_id=, :api_key=, :client
+  module_function :env=, :company_id=, :api_key=, :custom_environments=, :endpoint, :client
 end

--- a/lib/idnow/client.rb
+++ b/lib/idnow/client.rb
@@ -25,8 +25,8 @@ module Idnow
       fail 'Please set env to :test or :live' unless Idnow::ENVIRONMENTS.keys.include?(env)
       fail 'Please set your company_id' if company_id.nil?
       fail 'Please set your api_key' if api_key.nil?
-      @host        = Idnow::ENVIRONMENTS[env][:host]
-      @target_host = Idnow::ENVIRONMENTS[env][:target_host]
+      @host        = Idnow.endpoint(env, :host)
+      @target_host = Idnow.endpoint(env, :target_host)
       @company_id  = company_id
       @api_key     = api_key
 

--- a/lib/idnow/http_client.rb
+++ b/lib/idnow/http_client.rb
@@ -21,7 +21,7 @@ module Idnow
     def client
       Net::HTTP.new(@uri.host, @uri.port).tap do |http|
         http.read_timeout = @read_timeout
-        http.use_ssl      = true
+        http.use_ssl      = @uri.scheme == 'https'
       end
     end
   end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -29,6 +29,23 @@ RSpec.describe Idnow::Client do
         Idnow::Client.new(env: env, company_id: company_id, api_key: api_key)
       end
     end
+
+    context 'when a custom set of endpoints is configured' do
+      around do |example|
+        Idnow.custom_environments = {test: {host: 'https://gateway.test.idnow.example.com'}}
+        example.run
+        Idnow.custom_environments = nil
+      end
+
+      it 'initializes http and sftp clients with the custom hosts' do
+        expect(Idnow::HttpClient).to receive(:new)
+          .with(host: 'https://gateway.test.idnow.example.com')
+        expect(Idnow::SftpClient).to receive(:new)
+          .with(host: 'https://gateway.test.idnow.example.com', username: company_id, password: api_key)
+
+        Idnow::Client.new(env: env, company_id: company_id, api_key: api_key)
+      end
+    end
   end
 
   describe '#list_identifications' do

--- a/spec/unit/idnow_spec.rb
+++ b/spec/unit/idnow_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Idnow do
     Idnow.instance_variable_set(:@env, nil)
     Idnow.instance_variable_set(:@company_id, nil)
     Idnow.instance_variable_set(:@api_key, nil)
+    Idnow.instance_variable_set(:@custom_environments, nil)
     Idnow.instance_variable_set(:@client, nil)
   end
 
@@ -55,6 +56,21 @@ RSpec.describe Idnow do
 
     it 'sets api_key' do
       expect { subject }.to change { Idnow.instance_variable_get(:@api_key) }.to(api_key)
+    end
+  end
+
+  describe '.custom_environments=' do
+    subject { Idnow.custom_environments = custom_environments }
+
+    let(:custom_environments) { {test: {}, live: {}} }
+
+    it 'resets client' do
+      Idnow.instance_variable_set(:@client, 'dummy')
+      expect { subject }.to change { Idnow.instance_variable_get(:@client) }.to(nil)
+    end
+
+    it 'sets custom_environments' do
+      expect { subject }.to change { Idnow.instance_variable_get(:@custom_environments) }.to(custom_environments)
     end
   end
 


### PR DESCRIPTION
Hi @solarisBank,

thanks for providing this very nice library 🤓 
We're using it for a while now and have a small improvement we'd like to contribute.

Greets from Munich 🍺 

Matthias & Klaus

---

In some usecases it's required to configure a custom set of endpoints
this client should talk to (like non-standard versions of the IDnow
product or mock-service).

Example usage:

```ruby
Idnow.custom_environments = {
  test: {
    host:        'https://gateway.test.idnow.example.com',
    target_host: 'https://go.test.idnow.example.com'
  },
  live: {
    host:        'https://gateway.idnow.example.com',
    target_host: 'https://go.idnow.example.com'
  }
}
```