### PR TITLE
Sr/allow ruby 3.0

### DIFF
--- a/idnow-client.gemspec
+++ b/idnow-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'net-sftp', '~>2.1'
 
-  spec.required_ruby_version = '~> 2.3'
+  spec.required_ruby_version = '>= 2.3', '< 3.1'
 
   spec.add_development_dependency 'factory_bot', '~> 4.5'
   spec.add_development_dependency 'rspec', '~> 3.3'

--- a/lib/idnow/API/automated_testing.rb
+++ b/lib/idnow/API/automated_testing.rb
@@ -8,13 +8,13 @@ module Idnow
       def testing_start(transaction_number:)
         path = full_path_for("identifications/#{transaction_number}/start")
         request = Idnow::PostJsonRequest.new(path, {})
-        execute(request, 'X-API_KEY' => @api_key, http_client: automated_testing_http_client)
+        execute(request, { 'X-API_KEY' => @api_key }, http_client: automated_testing_http_client)
       end
 
       def testing_request_video_chat(transaction_number:)
         path = full_path_for("identifications/#{transaction_number}/requestVideoChat")
         request = Idnow::PostJsonRequest.new(path, {})
-        execute(request, 'X-API_KEY' => @api_key, http_client: automated_testing_http_client)
+        execute(request, { 'X-API_KEY' => @api_key }, http_client: automated_testing_http_client)
       end
     end
   end

--- a/lib/idnow/API/document_definitions.rb
+++ b/lib/idnow/API/document_definitions.rb
@@ -8,7 +8,7 @@ module Idnow
 
         path = full_path_for('documentdefinitions')
         request = Idnow::PostJsonRequest.new(path, document_data)
-        execute(request, 'X-API-LOGIN-TOKEN' => @auth_token)
+        execute(request, { 'X-API-LOGIN-TOKEN' => @auth_token })
       end
 
       def list_document_definitions
@@ -16,7 +16,7 @@ module Idnow
 
         path = full_path_for('documentdefinitions')
         request = Idnow::GetRequest.new(path)
-        response = execute(request, 'X-API-LOGIN-TOKEN' => @auth_token)
+        response = execute(request, { 'X-API-LOGIN-TOKEN' => @auth_token })
         response.data.map do |data|
           Idnow::DocumentDefinition.new(data)
         end

--- a/lib/idnow/API/download_documents.rb
+++ b/lib/idnow/API/download_documents.rb
@@ -8,7 +8,7 @@ module Idnow
 
         path = full_path_for("documentdefinitions/#{document_definition_identifier}/data")
         request = Idnow::GetRequest.new(path, '')
-        execute(request, 'X-API-LOGIN-TOKEN' => @auth_token)
+        execute(request, { 'X-API-LOGIN-TOKEN' => @auth_token })
       end
     end
   end

--- a/lib/idnow/API/request_identifications.rb
+++ b/lib/idnow/API/request_identifications.rb
@@ -6,7 +6,7 @@ module Idnow
       def request_identification(transaction_number:, identification_data:)
         path = full_path_for("identifications/#{transaction_number}/start")
         request = Idnow::PostJsonRequest.new(path, identification_data)
-        response = execute(request, 'X-API-KEY' => @api_key)
+        response = execute(request, { 'X-API-KEY' => @api_key })
         Idnow::IdentificationRequest.new(response.data, transaction_number, @target_host, @company_id)
       end
     end

--- a/lib/idnow/API/retrieve_identifications.rb
+++ b/lib/idnow/API/retrieve_identifications.rb
@@ -14,7 +14,7 @@ module Idnow
         partial_path = status.nil? ? 'identifications' : "identifications?#{status}=true"
         path = full_path_for(partial_path)
         request = Idnow::GetRequest.new(path)
-        response = execute(request, 'X-API-LOGIN-TOKEN' => @auth_token)
+        response = execute(request, { 'X-API-LOGIN-TOKEN' => @auth_token })
         response.data['identifications'].map do |data|
           Idnow::Identification.new(data)
         end
@@ -25,7 +25,7 @@ module Idnow
 
         path = full_path_for("identifications/#{transaction_number}")
         request = Idnow::GetRequest.new(path)
-        response = execute(request, 'X-API-LOGIN-TOKEN' => @auth_token)
+        response = execute(request, { 'X-API-LOGIN-TOKEN' => @auth_token })
         Idnow::Identification.new(response.data)
       end
 

--- a/lib/idnow/API/upload_documents.rb
+++ b/lib/idnow/API/upload_documents.rb
@@ -18,7 +18,7 @@ module Idnow
       def upload_document(file_data, request_path)
         raise Idnow::AuthenticationException if @auth_token.nil?
         request = Idnow::PostBinaryRequest.new(request_path, file_data)
-        execute(request, 'X-API-LOGIN-TOKEN' => @auth_token)
+        execute(request, { 'X-API-LOGIN-TOKEN' => @auth_token })
       end
     end
   end


### PR DESCRIPTION
Extend allowed versions of ruby to include 3.0.x and makes neccessary adjustments to the calling semantics to be compatible with ruby 3's keyword semantics.

Addresses Issue #54 