### PR TITLE
Support http file downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,11 @@ Idnow.client.list_identifications(status: 'pending')
 # keep in mind that it might take a while until the identification is completed.
 Idnow.client.get_identification(transaction_number: transaction_number)
 
-# Download identification files
+# Download identification file via SFTP
 Idnow.client.download_identification(transaction_number: transaction_number)
+
+# Get identification file via HTTP
+Idnow.client.get_identification_file(transaction_number: transaction_number)
 ```
 
 #### Esigning

--- a/lib/idnow/API/retrieve_identifications.rb
+++ b/lib/idnow/API/retrieve_identifications.rb
@@ -30,6 +30,14 @@ module Idnow
         Idnow::Identification.new(response.data)
       end
 
+      def get_identification_file(transaction_number:)
+        raise Idnow::AuthenticationException if @auth_token.nil?
+
+        path = full_path_for("identifications/#{transaction_number}.zip")
+        request = Idnow::GetRequest.new(path, '')
+        execute(request, { 'X-API-LOGIN-TOKEN' => @auth_token })
+      end
+
       def download_identification(transaction_number:)
         path = "#{transaction_number}.zip"
         @sftp_client.download(path)

--- a/spec/integration/retrieve_identification_file_spec.rb
+++ b/spec/integration/retrieve_identification_file_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'get identification file', :stub_connect do
+  subject { client.get_identification_file(transaction_number: transaction_number) }
+
+  let(:transaction_number) { '12345' }
+
+  before do
+    login
+  end
+
+  let!(:request) do
+    stub_request(:get, idnow_url("/identifications/#{transaction_number}.zip"))
+      .with(headers: { 'X-Api-Login-Token' => 'nekoThtua' })
+      .to_return(status: status, body: response_body)
+  end
+
+  context 'when the identification is successfully retrieved' do
+    let(:status) { 200 }
+    let(:response_body) { 'BINARY' }
+
+    it 'makes a request to the server' do
+      subject
+      expect(request).to have_been_made
+    end
+
+    it 'allows accessing the raw binary' do
+      expect(subject).to be_a Idnow::RawResponse
+      expect(subject.raw).to eq 'BINARY'
+    end
+  end
+
+  context 'when the identification returns errros' do
+    let(:status) { 404 }
+    let(:response_body) do
+      <<-JSON
+      {
+        "errors": [{
+            "cause":"OBJECT_NOT_FOUND",
+            "id":"12345","key":"token",
+            "message":"No identification found matching the provided parameters"
+          }]
+        }
+      JSON
+    end
+
+    it { expect { subject }.to raise_error(Idnow::ResponseException) }
+  end
+end


### PR DESCRIPTION
We have issues using the SFTP client due to incompatible SSL versions, however the http download still works for us. This new method allows downloading the identification file via HTTP and exposes it as a RawResponse.