### PR TITLE
Relax ruby requirements to allow usage by ruby 3.1

### DIFF
--- a/idnow-client.gemspec
+++ b/idnow-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'net-sftp', '~>2.1'
 
-  spec.required_ruby_version = '>= 2.5', '< 3.1'
+  spec.required_ruby_version = '>= 2.5', '< 3.2'
 
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
It looks like no actual code changes are necessary, just relaxing the requirements keeps the specs green.