### PR TITLE
Bump Ruby Version to 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ruby:2.5
+FROM ruby:2.7
 
 RUN mkdir /gem
 WORKDIR /gem
 
-COPY Gemfile idnow-client.gemspec /gem/
+COPY Gemfile *.lock idnow-client.gemspec /gem/
 RUN bundle install
 
 COPY . /gem/

--- a/idnow-client.gemspec
+++ b/idnow-client.gemspec
@@ -2,14 +2,12 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'idnow'
-  spec.version       = '2.3.0'
+  spec.version       = '2.4.0'
   spec.authors       = ['Joan Martinez, Tobias Bielohlawek']
   spec.email         = ['joan.martinez@solarisbank.de']
 
   spec.summary       = 'Ruby client for the IDnow API'
   spec.description   = 'Library to consume the IDnow API in Ruby, http://www.idnow.eu/developers'
-
-  raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.' unless spec.respond_to?(:metadata)
 
   spec.homepage      = 'https://github.com/solarisBank/idnow-client'
   spec.license       = 'MIT'
@@ -21,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'net-sftp', '~>2.1'
 
-  spec.required_ruby_version = '>= 2.5', '< 3.2'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'rspec'
@@ -29,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'shoulda-matchers'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
ruby < 2.7 is EOL. No reason to support it :)

And no reason to restrict future version, assuming forward compatibility
